### PR TITLE
Fixed Client is using wrong Private key

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ if (!endpointUrl) {
 
 
 const certificateFile = path.join(__dirname,"certificates","client_cert_2048.pem");
-const privateKeyFile  = path.join(__dirname,"certificates","PKI/own/private/private_key.pem" );
+const privateKeyFile  = path.join(__dirname,"certificates","client_key_2048.pem" );
 const options = {
     securityMode: securityMode,
     securityPolicy: securityPolicy,


### PR DESCRIPTION
The OPC UA Client is by default using the wrong Private key.
The default certificate and private key shall match in order to allow secured connection to OPC UA Servers