### PR TITLE
Missing Buildsteps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN dos2unix bin/opcua-commander
 # RUN npm install -g opcua-commander --unsafe-perm=true --allow-root
 # RUN npm install --unsafe-perm=true --allow-root
 # If you are building your code for production
-RUN npm ci --only=production --unsafe-perm=true --allow-root
-
+# The set registry can help in situations behind a firewall with scrict security settings and own CA Certificates.
+RUN npm config set registry http://registry.npmjs.org/ && npm ci --only=production --unsafe-perm=true --allow-root
+# Install typescript and build solution
+RUN npm install -g typescript && npm run build
 
 CMD [ "/bin/bash bin/opcua-commander" ]
 

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,9 @@ https://raw.githubusercontent.com/node-opcua/opcua-commander/master/docs/demo.gi
     $ git clone https://github.com/node-opcua/opcua-commander.git
     $ cd opcua-commander
     $ npm install
+    $ npm install -g typescript
+    $ npm run build
     $ node dist/index.js -e opc.tcp://localhost:26543 
-    
     
     
 ### install on ubuntu


### PR DESCRIPTION
There were some buildsteps missing which needed to be added.

Without this buildsteps its complaining about "dist/index.js" is missing, this is a file thats generated by npm build. Not sure why this was missing as its not running at all without this step?

Also added some snippet to help prevent errors with Firewalled / Proxied environments, so one has only to add certificates to his environment and nothing more.