### PR TITLE
Use DisplayName instead of BrowseName attribute for display

### DIFF
--- a/lib/model/model.ts
+++ b/lib/model/model.ts
@@ -52,7 +52,7 @@ const data = {
 
 export interface NodeChild {
   arrow: string;
-  browseName: string;
+  displayName: string;
   nodeId: NodeId;
   nodeClass: NodeClass;
 }
@@ -504,7 +504,7 @@ export class Model extends EventEmitter {
 
           children.push({
             arrow: referenceToSymbol(ref) + symbol(ref)[0],
-            browseName: ref.browseName.toString(),
+            displayName: ref.displayName.text || ref.browseName.toString(),
             nodeId: ref.nodeId,
             nodeClass: ref.nodeClass as number,
           });
@@ -517,7 +517,7 @@ export class Model extends EventEmitter {
           const ref = result.references[i];
           children.push({
             arrow: referenceToSymbol(ref) + symbol(ref)[0],
-            browseName: ref.browseName.toString(),
+            displayName: ref.displayName.text || ref.browseName.toString(),
             nodeId: ref.nodeId,
             nodeClass: ref.nodeClass as number,
           });
@@ -530,7 +530,7 @@ export class Model extends EventEmitter {
           const ref = result.references[i];
           children.push({
             arrow: referenceToSymbol(ref) + symbol(ref)[0],
-            browseName: ref.browseName.toString(),
+            displayName: ref.displayName.text || ref.browseName.toString(),
             nodeId: ref.nodeId,
             nodeClass: ref.nodeClass as number,
           });

--- a/lib/view/view.ts
+++ b/lib/view/view.ts
@@ -486,9 +486,9 @@ export class View {
             try {
                 let children = await this.model.expand_opcua_node(node);
 
-                // we sort the childrens by browseName alphabetically
+                // we sort the childrens by displayName alphabetically
                 children = children.sort((a: NodeChild,b: NodeChild) => {
-                    return a.browseName < b.browseName ? -1 : (a.browseName > b.browseName ? 1 : 0);
+                    return a.displayName < b.displayName ? -1 : (a.displayName > b.displayName ? 1 : 0);
                 });
 
                 const results = children.map((c: any) => (

--- a/lib/widget/tree_item.ts
+++ b/lib/widget/tree_item.ts
@@ -8,7 +8,7 @@ import { NodeClass } from "node-opcua-client";
 export class TreeItem {
     
     private arrow: string = "";
-    private browseName: string = "";
+    private displayName: string = "";
     private class: NodeClass = 1;
     private valueAsString: string = "";
 
@@ -21,7 +21,7 @@ export class TreeItem {
 
 
     get name(): string {
-        let str = this.arrow + " " + this.browseName;
+        let str = this.arrow + " " + this.displayName;
         if (this.class === NodeClass.Variable) {
             str += " = " + this.valueAsString;
         }


### PR DESCRIPTION
According to https://reference.opcfoundation.org/v104/Core/docs/Part3/5.2.4/ and https://reference.opcfoundation.org/v104/Core/docs/Part3/5.2.5/: 

- "... A _BrowseName_ should never be used to display the name of a _Node_. The _DisplayName_ should be used instead for this purpose...".
- "... _Clients_ should use this _Attribute_ if they want to display the name of the _Node_ to the user. They should not use the _BrowseName_ for this purpose..."

I had issues in case when _BrowseName_ in the model is different than _DisplayName_, and at the same time other 3rd party OPC clients behived correctly.

Now, _DisplayName_ is used. (If, by any chance it is not definied, it falls back to _BrowseName_)


