### PR TITLE
fix Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN dos2unix bin/opcua-commander
 # The set registry can help in situations behind a firewall with scrict security settings and own CA Certificates.
 RUN npm config set registry http://registry.npmjs.org/ && npm ci --only=production --unsafe-perm=true --allow-root
 # Install typescript and build solution
-RUN npm install -g typescript && npm run build
+RUN npm install && npm install -g typescript && npm run build
 
 ENTRYPOINT [ "./bin/opcua-commander" ]
 # to build


### PR DESCRIPTION
Adds `npm install` to the Dockerfile following the rest of installation instructions. 
With this change `master` Docker image builds. I've tested with a demo server and it seems to work fine.
Fixes: #41